### PR TITLE
Add definition of ROS_PACKAGE_NAME

### DIFF
--- a/ament_cmake_ros/CMakeLists.txt
+++ b/ament_cmake_ros/CMakeLists.txt
@@ -12,7 +12,7 @@ if(BUILD_TESTING)
 endif()
 
 ament_package(
-  CONFIG_EXTRAS "ament_cmake_ros-extras.cmake"
+  CONFIG_EXTRAS "ament_cmake_ros-extras.cmake.in"
 )
 
 install(

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -15,9 +15,4 @@
 # generated from ament_cmake_ros/ament_cmake_ros-extras.cmake.in
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
-
-if(NOT _AMENT_PACKAGE_NAME)
-  find_package(ament_cmake_core REQUIRED)
-  ament_package_xml()
-endif()
-add_definitions(-DROS_PACKAGE_NAME="${_AMENT_PACKAGE_NAME}")
+add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -1,18 +1,4 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# copied from ament_cmake_ros/ament_cmake_ros-extras.cmake
+# generated from ament_cmake_ros/ament_cmake_ros-extras.cmake.in
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
 add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -15,3 +15,4 @@
 # copied from ament_cmake_ros/ament_cmake_ros-extras.cmake
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
+add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# copied from ament_cmake_ros/ament_cmake_ros-extras.cmake
+# generated from ament_cmake_ros/ament_cmake_ros-extras.cmake.in
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
 add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -1,4 +1,18 @@
-# generated from ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from ament_cmake_ros/ament_cmake_ros-extras.cmake
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
 add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")

--- a/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
+++ b/ament_cmake_ros/ament_cmake_ros-extras.cmake.in
@@ -15,4 +15,9 @@
 # generated from ament_cmake_ros/ament_cmake_ros-extras.cmake.in
 
 include("${ament_cmake_ros_DIR}/build_shared_libs.cmake")
-add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
+
+if(NOT _AMENT_PACKAGE_NAME)
+  find_package(ament_cmake_core REQUIRED)
+  ament_package_xml()
+endif()
+add_definitions(-DROS_PACKAGE_NAME="${_AMENT_PACKAGE_NAME}")


### PR DESCRIPTION
~This is needed for using a package's name as the default logger/logger prefix for ROS_INFO etc.~ no longer needed for ros2/rclcpp#389

Putting it in this package as opposed to rclcpp (where the logging macros would make use the package name) means that packages below rclcpp e.g. rmw can also use this in their logging calls to rcutils directly.

However, it will require all packages e.g. demos to use ament_cmake_ros where they currently use ament_cmake, but I understand that we should be encouraging that anyway, correct?