### PR TITLE
Add pytest.ini to suppress warning output locally.

### DIFF
--- a/domain_coordinator/pytest.ini
+++ b/domain_coordinator/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

More explanation and CI over at https://github.com/ros2/ros2/issues/951