### PR TITLE
Warn if not Administrator on Windows

### DIFF
--- a/ament_cmake_ros/CMakeLists.txt
+++ b/ament_cmake_ros/CMakeLists.txt
@@ -11,13 +11,13 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package(
-  CONFIG_EXTRAS "ament_cmake_ros-extras.cmake.in"
-)
-
 if(WIN32)
   ament_environment_hooks(env_hook/warn_if_not_administrator.bat)
 endif()
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_ros-extras.cmake.in"
+)
 
 install(
   DIRECTORY cmake

--- a/ament_cmake_ros/CMakeLists.txt
+++ b/ament_cmake_ros/CMakeLists.txt
@@ -15,6 +15,10 @@ ament_package(
   CONFIG_EXTRAS "ament_cmake_ros-extras.cmake.in"
 )
 
+if(WIN32)
+  ament_environment_hooks(env_hook/warn_if_not_administrator.bat)
+endif()
+
 install(
   DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME}

--- a/ament_cmake_ros/env_hook/warn_if_not_administrator.bat
+++ b/ament_cmake_ros/env_hook/warn_if_not_administrator.bat
@@ -1,0 +1,7 @@
+net session >nul 2>&1
+if NOT %errorLevel% == 0 (
+    echo =======
+    echo Warning: ROS 2 executables require administrator permissions on Windows.
+    echo Programs may appear to work correctly, but might not be able communicate with other nodes.
+    echo =======
+)

--- a/ament_cmake_ros/env_hook/warn_if_not_administrator.bat
+++ b/ament_cmake_ros/env_hook/warn_if_not_administrator.bat
@@ -1,7 +1,7 @@
 net session >nul 2>&1
 if NOT %errorLevel% == 0 (
     echo =======
-    echo Warning: ROS 2 executables require administrator permissions on Windows.
+    echo Warning: ROS 2 executables require administrator permissions on Windows when using the default middleware (rmw_fastrtps_cpp).
     echo Programs may appear to work correctly, but might not be able communicate with other nodes.
     echo =======
 )


### PR DESCRIPTION
While testing Humble I'm seeing that communication between processes only works when they're both launched from administrator command prompts. If one or both is launched from a normal `cmd.exe`, then the nodes appear to function correctly but never communicate.

I think that behavior might be confusing to a user, so this PR adds an environment hook that should print a warning when the workspace setup scripts are called.