### PR TITLE
Add rmw_test_fixture for supporting RMW-isolated testing

### DIFF
--- a/rmw_test_fixture/CMakeLists.txt
+++ b/rmw_test_fixture/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.5)
+project(rmw_test_fixture LANGUAGES NONE)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  rmw::rmw
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(rmw)
+
+ament_package()

--- a/rmw_test_fixture/include/rmw_test_fixture/rmw_test_fixture.h
+++ b/rmw_test_fixture/include/rmw_test_fixture/rmw_test_fixture.h
@@ -1,0 +1,57 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_TEST_FIXTURE__RMW_TEST_FIXTURE_H_
+#define RMW_TEST_FIXTURE__RMW_TEST_FIXTURE_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <rmw/macros.h>
+#include <rmw/types.h>
+
+#include "rmw_test_fixture/visibility_control.h"
+
+/// Begin isolating ROS communication in this process.
+/**
+ * Perform neccessary changes to the process and/or environment so that any
+ * attempted ROS communication will be isolated from other processes.
+ *
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_TEST_FIXTURE_PUBLIC
+RMW_WARN_UNUSED
+rmw_ret_t
+rmw_test_isolation_start();
+
+/// Cease isolation of ROS communication in this process.
+/**
+ * Restore the process and/or environment to the previous state and deallocate
+ * any resources previously allocated by rmw_test_isolation_start().
+ *
+ * \return `RMW_RET_OK` if successful, or
+ * \return `RMW_RET_ERROR` if an unexpected error occurs.
+ */
+RMW_TEST_FIXTURE_PUBLIC
+rmw_ret_t
+rmw_test_isolation_stop();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW_TEST_FIXTURE__RMW_TEST_FIXTURE_H_

--- a/rmw_test_fixture/include/rmw_test_fixture/visibility_control.h
+++ b/rmw_test_fixture/include/rmw_test_fixture/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_TEST_FIXTURE__VISIBILITY_CONTROL_H_
+#define RMW_TEST_FIXTURE__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RMW_TEST_FIXTURE_EXPORT __attribute__ ((dllexport))
+    #define RMW_TEST_FIXTURE_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RMW_TEST_FIXTURE_EXPORT __declspec(dllexport)
+    #define RMW_TEST_FIXTURE_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RMW_TEST_FIXTURE_BUILDING_LIBRARY
+    #define RMW_TEST_FIXTURE_PUBLIC RMW_TEST_FIXTURE_EXPORT
+  #else
+    #define RMW_TEST_FIXTURE_PUBLIC RMW_TEST_FIXTURE_IMPORT
+  #endif
+  #define RMW_TEST_FIXTURE_PUBLIC_TYPE RMW_TEST_FIXTURE_PUBLIC
+  #define RMW_TEST_FIXTURE_LOCAL
+#else
+  #define RMW_TEST_FIXTURE_EXPORT __attribute__ ((visibility("default")))
+  #define RMW_TEST_FIXTURE_IMPORT
+  #if __GNUC__ >= 4
+    #define RMW_TEST_FIXTURE_PUBLIC __attribute__ ((visibility("default")))
+    #define RMW_TEST_FIXTURE_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RMW_TEST_FIXTURE_PUBLIC
+    #define RMW_TEST_FIXTURE_LOCAL
+  #endif
+  #define RMW_TEST_FIXTURE_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RMW_TEST_FIXTURE__VISIBILITY_CONTROL_H_

--- a/rmw_test_fixture/package.xml
+++ b/rmw_test_fixture/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmw_test_fixture</name>
+  <version>0.14.0</version>
+  <description>Plugin interface for tools for isolating ROS communication at the RMW layer</description>
+
+  <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="logans@cottsay.net">Scott K Logan</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
+
+  <build_export_depend>rmw</build_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmw_test_fixture_implementation/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.5)
+project(rmw_test_fixture_implementation LANGUAGES C CXX)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# By default, without the settings below, find_package(Python3) will attempt
+# to find the newest python version it can, and additionally will find the
+# most specific version.  For instance, on a system that has
+# /usr/bin/python3.10, /usr/bin/python3.11, and /usr/bin/python3, it will find
+# /usr/bin/python3.11, even if /usr/bin/python3 points to /usr/bin/python3.10.
+# The behavior we want is to prefer the "system" installed version unless the
+# user specifically tells us othewise through the Python3_EXECUTABLE hint.
+# Setting CMP0094 to NEW means that the search will stop after the first
+# python version is found.  Setting Python3_FIND_UNVERSIONED_NAMES means that
+# the search will prefer /usr/bin/python3 over /usr/bin/python3.11.  And that
+# latter functionality is only available in CMake 3.20 or later, so we need
+# at least that version.
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
+
+find_package(rcutils REQUIRED)
+find_package(rcpputils REQUIRED)
+find_package(rmw_implementation REQUIRED)
+find_package(rmw_test_fixture REQUIRED)
+
+add_library(rmw_test_fixture_implementation
+  src/rmw_test_fixture_implementation.cpp
+)
+target_compile_definitions(rmw_test_fixture_implementation PRIVATE
+  RMW_TEST_FIXTURE_IMPLEMENTATION_BUILDING_DLL
+)
+target_link_libraries(rmw_test_fixture_implementation PRIVATE
+  rcpputils::rcpputils
+  rmw_implementation::rmw_implementation
+)
+target_link_libraries(rmw_test_fixture_implementation PUBLIC
+  rmw_test_fixture::rmw_test_fixture
+)
+
+add_executable(run_rmw_isolated
+  src/run_rmw_isolated.c
+)
+target_link_libraries(run_rmw_isolated
+  rcutils::rcutils
+  rmw_test_fixture_implementation
+)
+
+install(
+  TARGETS rmw_test_fixture_implementation run_rmw_isolated
+  EXPORT ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_python_install_package(${PROJECT_NAME})
+
+python3_add_library(_rmw_test_fixture_implementation
+  src/rmw_test_fixture_implementation_py.c
+)
+
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # python3_add_library should really take care of this for us, but it doesn't
+  set_target_properties(_rmw_test_fixture_implementation PROPERTIES DEBUG_POSTFIX "_d")
+endif()
+
+# Set output directories to import module from the build directory
+# Use a no-op generator expression so multi-config generators don't append an
+# extra directory like Release/ or Debug/ and break the Python import.
+set_target_properties(_rmw_test_fixture_implementation PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}>"
+  RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_CURRENT_BINARY_DIR}/test_${PROJECT_NAME}>"
+)
+
+target_link_libraries(_rmw_test_fixture_implementation PRIVATE
+  rmw_test_fixture_implementation
+)
+
+install(TARGETS
+  _rmw_test_fixture_implementation
+  DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(
+  rmw_test_fixture
+)
+
+ament_package()

--- a/rmw_test_fixture_implementation/package.xml
+++ b/rmw_test_fixture_implementation/package.xml
@@ -19,6 +19,7 @@
   <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
   <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_zenoh_cpp</exec_depend>
 
+  <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>rmw_implementation</depend>
   <depend>rmw_test_fixture</depend>

--- a/rmw_test_fixture_implementation/package.xml
+++ b/rmw_test_fixture_implementation/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmw_test_fixture_implementation</name>
+  <version>0.14.0</version>
+  <description>Tools for isolating ROS environments at the RMW layer</description>
+
+  <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="logans@cottsay.net">Scott K Logan</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
+
+  <build_depend>python3-dev</build_depend>
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_zenoh_cpp</exec_depend>
+
+  <depend>rcutils</depend>
+  <depend>rmw_implementation</depend>
+  <depend>rmw_test_fixture</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <group_depend>rmw_test_fixture_implementation_packages</group_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmw_test_fixture_implementation/rmw_test_fixture_implementation/__init__.py
+++ b/rmw_test_fixture_implementation/rmw_test_fixture_implementation/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import AbstractContextManager
+
+from rmw_test_fixture_implementation._rmw_test_fixture_implementation \
+    import rmw_test_isolation_start
+from rmw_test_fixture_implementation._rmw_test_fixture_implementation \
+    import rmw_test_isolation_stop
+
+__all__ = ['RMWTestIsolator']
+
+
+class RMWTestIsolator(AbstractContextManager):
+    """Manages RMW test isolation for the current process."""
+
+    def __enter__(self):
+        rmw_test_isolation_start()
+        return super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        rmw_test_isolation_stop()
+        return super().__exit__(exc_type, exc_value, traceback)

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
@@ -1,0 +1,128 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rmw/macros.h>
+#include <rmw/rmw.h>
+#include <rmw/types.h>
+
+#include <memory>
+
+#include <rcpputils/env.hpp>
+#include <rcpputils/shared_library.hpp>
+#include <rmw_test_fixture/rmw_test_fixture.h>
+
+static
+rmw_ret_t
+rmw_test_isolation_init();
+
+static
+rmw_ret_t
+rmw_test_isolation_stop_noop();
+
+static rmw_ret_t (*symbol_rmw_test_isolation_start)() = rmw_test_isolation_init;
+static rmw_ret_t (*symbol_rmw_test_isolation_stop)() = rmw_test_isolation_stop_noop;
+
+static std::unique_ptr<rcpputils::SharedLibrary> g_isolation_lib = nullptr;
+
+static
+rmw_ret_t
+rmw_test_isolation_start_default()
+{
+  return RMW_RET_UNSUPPORTED;
+}
+
+static
+rmw_ret_t
+rmw_test_isolation_stop_default()
+{
+  return RMW_RET_UNSUPPORTED;
+}
+
+static
+rmw_ret_t
+rmw_test_isolation_start_noop()
+{
+  return RMW_RET_OK;
+}
+
+static
+rmw_ret_t
+rmw_test_isolation_stop_noop()
+{
+  return RMW_RET_OK;
+}
+
+static
+rmw_ret_t
+rmw_test_isolation_init()
+{
+  if (!rcpputils::get_env_var("RMW_TEST_FIXTURE_DISABLE_ISOLATION").empty()) {
+    symbol_rmw_test_isolation_start = rmw_test_isolation_start_noop;
+    return symbol_rmw_test_isolation_start();
+  }
+
+  const char * rmw_id = rmw_get_implementation_identifier();
+
+  if (rmw_id != NULL) {
+    std::string library = std::string(rmw_id) + "_test_fixture";
+    std::string library_name = rcpputils::get_platform_library_name(library);
+
+    try {
+      g_isolation_lib = std::make_unique<rcpputils::SharedLibrary>(library_name);
+    } catch (const std::runtime_error & e) {
+      // no library available, fall back to default isolation
+    }
+  }
+
+  if (g_isolation_lib) {
+    void *symbol = g_isolation_lib->get_symbol("rmw_test_isolation_start");
+    if (symbol == nullptr) {
+      g_isolation_lib.reset();
+      return RMW_RET_ERROR;
+    }
+
+    symbol_rmw_test_isolation_start = (rmw_ret_t (*)())symbol;
+
+    symbol = g_isolation_lib->get_symbol("rmw_test_isolation_stop");
+    if (symbol != nullptr) {
+      symbol_rmw_test_isolation_stop = (rmw_ret_t (*)())symbol;
+    }
+  } else {
+    symbol_rmw_test_isolation_start = rmw_test_isolation_start_default;
+    symbol_rmw_test_isolation_stop = rmw_test_isolation_stop_default;
+  }
+
+  return symbol_rmw_test_isolation_start();
+}
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+rmw_ret_t
+rmw_test_isolation_start()
+{
+  return symbol_rmw_test_isolation_start();
+}
+
+rmw_ret_t
+rmw_test_isolation_stop()
+{
+  return symbol_rmw_test_isolation_stop();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
@@ -16,11 +16,14 @@
 #include <rmw/rmw.h>
 #include <rmw/types.h>
 
+#include <rmw_test_fixture/rmw_test_fixture.h>
+
 #include <memory>
+#include <stdexcept>
+#include <string>
 
 #include <rcpputils/env.hpp>
 #include <rcpputils/shared_library.hpp>
-#include <rmw_test_fixture/rmw_test_fixture.h>
 
 static
 rmw_ret_t

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
@@ -1,0 +1,158 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdbool.h>
+
+#include <Python.h>
+
+#include <rmw_test_fixture/rmw_test_fixture.h>
+
+static PyObject * get_fresh_environ()
+{
+  PyThreadState *sub_state = Py_NewInterpreter();
+  if (NULL == sub_state) {
+    return NULL;
+  }
+
+  PyObject *os = PyImport_ImportModule("os");
+  if (NULL == os) {
+    Py_EndInterpreter(sub_state);
+    return NULL;
+  }
+
+  PyObject *environ = PyObject_GetAttrString(os, "environ");
+  Py_DECREF(os);
+  if (NULL == environ) {
+    return NULL;
+  }
+
+  PyObject *fresh_environ = PyMapping_Items(environ);
+  Py_DECREF(environ);
+  Py_EndInterpreter(sub_state);
+  return fresh_environ;
+}
+
+/// Reload Python's os.environ from the process values.
+/**
+ * Python maintains a cache of the environment variables and when they are
+ * modified from C, Python doesn't have any way to know. It appears that
+ * Python 3.14 will provide a supported mechanism to reload the variables,
+ * but for now, this process appears to safely achieve the same effect.
+ *
+ * At a high level:
+ * 1. Spin up a new sub-interpreter. Upon importing `os`, it will reload
+ *    the environment variables from C.
+ * 2. Copy the list of environment variables out of `os.environ`.
+ * 3. Destroy the sub-interpreter and switch back to the original one.
+ * 4. Clear all of the environment variables from `os.environ`.
+ * 5. Re-populate the variables with the fresh ones dumped from the
+ *    sub-interpreter.
+ *
+ * \return true if the variables were reloaded successfully, or
+ * \return false if an unspecified error occurs.
+ */
+static bool reload_environ()
+{
+  PyThreadState *orig_state = PyThreadState_Swap(NULL);
+
+  PyObject * fresh_environ = get_fresh_environ();
+  PyThreadState_Swap(orig_state);
+  if (NULL == fresh_environ) {
+    return false;
+  }
+
+  PyObject *os = PyImport_ImportModule("os");
+  if (NULL == os) {
+    Py_DECREF(fresh_environ);
+    return false;
+  }
+
+  PyObject *environ = PyObject_GetAttrString(os, "environ");
+  Py_DECREF(os);
+  if (NULL == environ) {
+    Py_DECREF(fresh_environ);
+    return false;
+  }
+
+  PyObject *res = PyObject_CallMethod(environ, "clear", NULL);
+  if (NULL == res) {
+    Py_DECREF(environ);
+    Py_DECREF(fresh_environ);
+    return false;
+  }
+
+  res = PyObject_CallMethod(environ, "update", "O", fresh_environ);
+  Py_DECREF(environ);
+  Py_DECREF(fresh_environ);
+
+  return true;
+}
+
+static PyObject *
+isolation_start(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  rmw_ret_t ret = rmw_test_isolation_start();
+  if (RMW_RET_OK != ret) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to start RMW isolation (%d)", ret);
+    return NULL;
+  }
+
+  if (!reload_environ()) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment");
+    return NULL;
+  }
+
+  Py_RETURN_NONE;
+}
+
+static PyObject *
+isolation_stop(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
+{
+  rmw_ret_t ret = rmw_test_isolation_stop();
+  if (RMW_RET_OK != ret) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to stop RMW isolation (%d)", ret);
+    return NULL;
+  }
+
+  if (!reload_environ()) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment");
+    return NULL;
+  }
+
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef module_methods[] = {
+  {"rmw_test_isolation_start", isolation_start, METH_NOARGS, "Start RMW isolation."},
+  {"rmw_test_isolation_stop", isolation_stop, METH_NOARGS, "Stop RMW isolation."},
+  {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef module = {
+  PyModuleDef_HEAD_INIT,
+  "_rmw_test_fixtupre_implementation",
+  NULL,
+  -1,
+  module_methods,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+};
+
+PyMODINIT_FUNC
+PyInit__rmw_test_fixture_implementation(void)
+{
+  return PyModule_Create(&module);
+}

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
@@ -31,14 +31,14 @@ static PyObject * get_fresh_environ()
     return NULL;
   }
 
-  PyObject *environ = PyObject_GetAttrString(os, "environ");
+  PyObject *os_environ = PyObject_GetAttrString(os, "environ");
   Py_DECREF(os);
-  if (NULL == environ) {
+  if (NULL == os_environ) {
     return NULL;
   }
 
-  PyObject *fresh_environ = PyMapping_Items(environ);
-  Py_DECREF(environ);
+  PyObject *fresh_environ = PyMapping_Items(os_environ);
+  Py_DECREF(os_environ);
   Py_EndInterpreter(sub_state);
   return fresh_environ;
 }
@@ -78,22 +78,22 @@ static bool reload_environ()
     return false;
   }
 
-  PyObject *environ = PyObject_GetAttrString(os, "environ");
+  PyObject *os_environ = PyObject_GetAttrString(os, "environ");
   Py_DECREF(os);
-  if (NULL == environ) {
+  if (NULL == os_environ) {
     Py_DECREF(fresh_environ);
     return false;
   }
 
-  PyObject *res = PyObject_CallMethod(environ, "clear", NULL);
+  PyObject *res = PyObject_CallMethod(os_environ, "clear", NULL);
   if (NULL == res) {
-    Py_DECREF(environ);
+    Py_DECREF(os_environ);
     Py_DECREF(fresh_environ);
     return false;
   }
 
-  res = PyObject_CallMethod(environ, "update", "O", fresh_environ);
-  Py_DECREF(environ);
+  res = PyObject_CallMethod(os_environ, "update", "O", fresh_environ);
+  Py_DECREF(os_environ);
   Py_DECREF(fresh_environ);
 
   return true;

--- a/rmw_test_fixture_implementation/src/run_rmw_isolated.c
+++ b/rmw_test_fixture_implementation/src/run_rmw_isolated.c
@@ -14,9 +14,8 @@
 
 #include <errno.h>
 #include <stdio.h>
-#include <unistd.h>
 
-#ifndef _WIN32
+#if !defined _WIN32 && !defined __CYGWIN__
 #include <signal.h>
 #endif
 
@@ -62,7 +61,7 @@ main(int argc, char *argv[])
     return rmw_ret;
   }
 
-#ifndef _WIN32
+#if !defined _WIN32 && !defined __CYGWIN__
   // Let the signal propagate to the child process - this process should only
   // exit once the child process does.
   signal(SIGINT, SIG_IGN);

--- a/rmw_test_fixture_implementation/src/run_rmw_isolated.c
+++ b/rmw_test_fixture_implementation/src/run_rmw_isolated.c
@@ -1,0 +1,98 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#ifndef _WIN32
+#include <signal.h>
+#endif
+
+#include <rcutils/allocator.h>
+#include <rcutils/process.h>
+#include <rcutils/strdup.h>
+#include <rcutils/types.h>
+
+#include <rmw_test_fixture/rmw_test_fixture.h>
+
+int
+main(int argc, char *argv[])
+{
+  int exit_code;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_ret_t rcutils_ret;
+  rcutils_string_array_t args = rcutils_get_zero_initialized_string_array();
+  rcutils_process_t * process;
+  rmw_ret_t rmw_ret;
+
+  if (argc < 2) {
+    fprintf(stderr, "Usage: %s PROGRAM_NAME [PROGRAM_ARGS ...]\n", argv[0]);
+    return EINVAL;
+  }
+
+  rcutils_ret = rcutils_string_array_init(&args, argc - 1, &allocator);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    fprintf(stderr, "Failed to initialize argument array (%d)\n", rcutils_ret);
+    return rcutils_ret;
+  }
+
+  for (int i = 1; i < argc; i++) {
+    args.data[i - 1] = rcutils_strdup(argv[i], allocator);
+    if (NULL == args.data[i - 1]) {
+      fprintf(stderr, "Failed to populate argument array\n");
+      return 1;
+    }
+  }
+
+  rmw_ret = rmw_test_isolation_start();
+  if (RMW_RET_OK != rmw_ret) {
+    fprintf(stderr, "Failed to start RMW isolation (%d)\n", rmw_ret);
+    return rmw_ret;
+  }
+
+#ifndef _WIN32
+  // Let the signal propagate to the child process - this process should only
+  // exit once the child process does.
+  signal(SIGINT, SIG_IGN);
+#endif
+
+  process = rcutils_start_process(&args, &allocator);
+  if (NULL == process) {
+    fprintf(stderr, "Failed to run %s\n", argv[1]);
+    return 1;
+  }
+
+  rcutils_ret = rcutils_string_array_fini(&args);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    fprintf(stderr, "Failed to free argument array (%d)\n", rcutils_ret);
+    return rcutils_ret;
+  }
+
+  rcutils_ret = rcutils_process_wait(process, &exit_code);
+  if (RCUTILS_RET_OK != rcutils_ret) {
+    fprintf(stderr, "Failed to wait for subprocess termination (%d)\n", rcutils_ret);
+    return rcutils_ret;
+  }
+
+  rcutils_process_close(process);
+
+  rmw_ret = rmw_test_isolation_stop();
+  if (RMW_RET_OK != rmw_ret) {
+    fprintf(stderr, "Failed to stop RMW isolation (%d)\n", rmw_ret);
+    return rmw_ret;
+  }
+
+  return exit_code;
+}


### PR DESCRIPTION
This change includes two new packages which provide a extensible mechanism for creating a test fixture for RMW-based communication isolation. It is modeled closely after the `rmw` and `rmw_implementation` API.

The `rmw_test_fixture` package currently provides only the API, which could be implemented by an RMW provider for configuring their RMW for a test to run. The plugin could do things like:
1. Change environment variables in the current process
2. Create temporary configuration files
3. Spawn threads or subprocesses

The `rmw_test_fixture_implementation` package provides the entry point for discovering, loading, and invoking the appropriate extension. There are currently 3 ways this can be done:
1. Link against the `rmw_test_fixture_implementation` library and invoke the functions
2. Invoke the `run_rmw_isolated` wrapper executable giving it the command that should be isolated
3. Use the `rmw_test_fixture_implementation.RMWTestIsolator` Python class

An example implementation of a test fixture extension is here: https://github.com/ros2/rmw_zenoh/compare/rolling...cottsay/rmw_test_fixture

An example of how the fixture can be used to run automated tests is here: https://github.com/ros2/launch_ros/compare/rolling...cottsay/rmw_test_fixture