### PR TITLE
Ignore Ctrl-C in run_rmw_isolated on Windows

### DIFF
--- a/rmw_test_fixture_implementation/src/run_rmw_isolated.c
+++ b/rmw_test_fixture_implementation/src/run_rmw_isolated.c
@@ -26,6 +26,13 @@
 
 #include <rmw_test_fixture/rmw_test_fixture.h>
 
+#if defined _WIN32 || defined __CYGWIN__
+bool ctrl_c_handler(int signal)
+{
+  return false;
+}
+#endif
+
 int
 main(int argc, char *argv[])
 {
@@ -61,9 +68,11 @@ main(int argc, char *argv[])
     return rmw_ret;
   }
 
-#if !defined _WIN32 && !defined __CYGWIN__
   // Let the signal propagate to the child process - this process should only
   // exit once the child process does.
+#if defined _WIN32 || defined __CYGWIN__
+  SetConsoleCtrlHandler((PHANDLER_ROUTINE)ctrl_c_handler, TRUE);
+#else
   signal(SIGINT, SIG_IGN);
 #endif
 


### PR DESCRIPTION
Like Linux, we want to ignore the signal in the wrapper process and let it propagate to the child process. Note that we explicitly handle the signal and do nothing rather than pass NULL to the function call. The latter would propagate to the subprocess, which we don't want to happen.