### PR TITLE
Switch from 'domain_coordinator' to 'rmw_test_fixture'

### DIFF
--- a/ament_cmake_ros/package.xml
+++ b/ament_cmake_ros/package.xml
@@ -13,13 +13,14 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>domain_coordinator</depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_gtest</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_gmock</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_pytest</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_ros_core</buildtool_export_depend>
+
+  <exec_depend>rmw_test_fixture_implementation</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
We should probably revisit the ament_cmake_test API at some point rather than messing with the raw command line arguments like this, though it's worth noting that ament_cmake_test does the same sort of thing before it parses the arguments anyway.