### PR TITLE
Add ament_add_ros_isolated_{gmock,gtest}_test macros

### DIFF
--- a/ament_cmake_ros/cmake/ament_add_ros_isolated_gmock.cmake
+++ b/ament_cmake_ros/cmake/ament_add_ros_isolated_gmock.cmake
@@ -37,3 +37,29 @@ function(ament_add_ros_isolated_gmock target)
   )
 
 endfunction()
+
+#
+# Add an existing gmock test that runs with ROS_DOMAIN_ID isolation.
+# If no ROS_DOMAIN_ID is set, automatically select one not in use by another
+# isolated test before running the target test.
+# This will prevent tests running in parallel from interfering with
+# one-another.
+#
+# This behavior can be disabled for debugging in two ways:
+# 1) Creating an environment variable called DISABLE_ROS_ISOLATION
+# 2) Setting a ROS_DOMAIN_ID environment variable.
+#    This will cause the tests to use that ROS_DOMAIN_ID.
+#
+# Parameters are the same as ament_add_gmock
+
+function(ament_add_ros_isolated_gmock_test target)
+
+  set(RUNNER "RUNNER" "${ament_cmake_ros_DIR}/run_test_isolated.py")
+
+  ament_add_gmock_test(
+    "${target}"
+    RUNNER "${RUNNER}"
+    ${ARGN}
+  )
+
+endfunction()

--- a/ament_cmake_ros/cmake/ament_add_ros_isolated_gtest.cmake
+++ b/ament_cmake_ros/cmake/ament_add_ros_isolated_gtest.cmake
@@ -37,3 +37,29 @@ function(ament_add_ros_isolated_gtest target)
   )
 
 endfunction()
+
+#
+# Add an existing gtest that runs with ROS_DOMAIN_ID isolation.
+# If no ROS_DOMAIN_ID is set, automatically select one not in use by another
+# isolated test before running the target test.
+# This will prevent tests running in parallel from interfering with
+# one-another.
+#
+# This behavior can be disabled for debugging in two ways:
+# 1) Creating an environment variable called DISABLE_ROS_ISOLATION
+# 2) Setting a ROS_DOMAIN_ID environment variable.
+#    This will cause the tests to use that ROS_DOMAIN_ID.
+#
+# Parameters are the same as ament_add_gtest
+
+function(ament_add_ros_isolated_gtest_test target)
+
+  set(RUNNER "RUNNER" "${ament_cmake_ros_DIR}/run_test_isolated.py")
+
+  ament_add_gtest_test(
+    "${target}"
+    RUNNER "${RUNNER}"
+    ${ARGN}
+  )
+
+endfunction()


### PR DESCRIPTION
Additional wrapper macros to complement the existing ones. The ones ending in `_test` like this do not implicitly create the executable, which must be created separately by `ament_add_{gmock,gtest}_executable`. That macro doesn't need an isolated counterpart.