### PR TITLE
Stop loading RMW to load the test fixture

### DIFF
--- a/rmw_test_fixture_implementation/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/CMakeLists.txt
@@ -28,8 +28,10 @@ find_package(ament_cmake_ros_core REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
-find_package(rmw_implementation REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
 find_package(rmw_test_fixture REQUIRED)
+
+get_default_rmw_implementation(RMW_IMPLEMENTATION)
 
 add_library(rmw_test_fixture_implementation
   src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -39,13 +41,13 @@ target_include_directories(rmw_test_fixture_implementation PRIVATE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 )
 target_compile_definitions(rmw_test_fixture_implementation PRIVATE
-  RMW_TEST_FIXTURE_BUILDING_DLL
+  "DEFAULT_RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}"
+  "RMW_TEST_FIXTURE_BUILDING_DLL"
 )
 target_link_libraries(rmw_test_fixture_implementation PRIVATE
   rcpputils::rcpputils
   rcutils::rcutils
   rmw::rmw
-  rmw_implementation::rmw_implementation
   $<$<BOOL:${WIN32}>:ws2_32 wsock32>
 )
 target_link_libraries(rmw_test_fixture_implementation PUBLIC

--- a/rmw_test_fixture_implementation/package.xml
+++ b/rmw_test_fixture_implementation/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>python3-dev</build_depend>
+  <build_depend>rmw_implementation</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
 
   <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->

--- a/rmw_test_fixture_implementation/package.xml
+++ b/rmw_test_fixture_implementation/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>python3-dev</build_depend>
+  <build_depend>rmw_implementation_cmake</build_depend>
 
   <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
   <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_zenoh_cpp</exec_depend>
@@ -22,7 +23,6 @@
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>rmw</depend>
-  <depend>rmw_implementation</depend>
   <depend>rmw_test_fixture</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
This change mirrors part of the RMW selection algorithm implemented in rmw_implementation so that we can avoid actually loading the RMW just to figure out what it's called.

The main reason we don't want to rely on the loaded RMW is that a testing process may change the RMW_IMPLEMENTATION variable after starting up with intent to invoke a subprocess that needs to be isolated. We should assume that future communication will happen based on the current environment variables, not the state when the process started.