### PR TITLE
Don't set ROS_AUTOMATIC_DISCOVERY_RANGE in rmw_test_fixture

### DIFF
--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -171,13 +171,6 @@ rmw_test_isolation_start_default()
   // Avoid ROS_DOMAIN_ID=0 entirely
   slot += 1;
 
-  if (!rcutils_set_env("ROS_AUTOMATIC_DISCOVERY_RANGE", "LOCALHOST")) {
-    fprintf(stderr, "Failed to update ROS_AUTOMATIC_DISCOVERY_RANGE\n");
-    port_lock_fini(g_lock);
-    g_lock = INVALID_PORT_LOCK;
-    return RMW_RET_ERROR;
-  }
-
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char *env_val = rcutils_format_string(allocator, "%d", slot);
   if (NULL == env_val) {
@@ -190,9 +183,6 @@ rmw_test_isolation_start_default()
   if (!rcutils_set_env("ROS_DOMAIN_ID", env_val)) {
     fprintf(stderr, "Failed to update ROS_DOMAIN_ID\n");
     allocator.deallocate(env_val, &allocator.state);
-    if (!rcutils_set_env("ROS_AUTOMATIC_DISCOVERY_RANGE", NULL)) {
-      fprintf(stderr, "Failed to clear ROS_AUTOMATIC_DISCOVERY_RANGE\n");
-    }
     port_lock_fini(g_lock);
     g_lock = INVALID_PORT_LOCK;
     return RMW_RET_ERROR;
@@ -208,10 +198,6 @@ rmw_test_isolation_stop_default()
 {
   if (!rcutils_set_env("ROS_DOMAIN_ID", NULL)) {
     fprintf(stderr, "Failed to clear ROS_DOMAIN_ID\n");
-  }
-
-  if (!rcutils_set_env("ROS_AUTOMATIC_DISCOVERY_RANGE", NULL)) {
-    fprintf(stderr, "Failed to clear ROS_AUTOMATIC_DISCOVERY_RANGE\n");
   }
 
   port_lock_fini(g_lock);


### PR DESCRIPTION
There seems to be a bug somewhere that makes this setting misbehave sporadically on Windows builds. Until we can get to the bottom of that, we'll need to drop it.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=23169)](http://ci.ros2.org/job/ci_linux/23169/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=17378)](http://ci.ros2.org/job/ci_linux-aarch64/17378/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=2636)](http://ci.ros2.org/job/ci_linux-rhel/2636/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24040)](http://ci.ros2.org/job/ci_windows/24040/)