### PR TITLE
Add missing build_export_depend on ament_cmake_libraries

### DIFF
--- a/ament_cmake_ros_core/package.xml
+++ b/ament_cmake_ros_core/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_libraries</buildtool_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This is an exported dependency from using ament_cmake_export_dependencies.