### PR TITLE
Choose random domain IDs during default RMW isolation

### DIFF
--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -57,6 +57,10 @@ typedef int port_lock_t;
 
 static port_lock_t g_lock = INVALID_PORT_LOCK;
 
+static unsigned int g_random_seed;
+
+static bool g_random_seed_initialized = false;
+
 static
 void
 port_lock_fini(port_lock_t lock)
@@ -111,7 +115,14 @@ port_lock_init(uint16_t start, uint16_t end, uint16_t *slot)
     return INVALID_PORT_LOCK;
   }
 
-  uint16_t offset = rcutils_get_pid() % (end - start);
+  if (!g_random_seed_initialized) {
+    g_random_seed = rcutils_get_pid();
+    g_random_seed_initialized = true;
+  }
+
+  g_random_seed = g_random_seed * 1103515245 + 12345;
+  uint16_t offset = g_random_seed % (end - start);
+
   struct sockaddr_in addr;
   memset(&addr, 0x0, sizeof(addr));
   addr.sin_family = AF_INET;


### PR DESCRIPTION
Previous behavior is to choose the ROS_DOMAIN_ID based on the current process ID. While this is sufficient for most applications, it will always attempt to use the same ID when restarted within the same process.

This change switches to a simple LCG for choosing a pseudo-random ID each time the fixture is run, and uses the process ID as a seed.

(LCG constants were taken from glibc's implementation)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24070)](http://ci.ros2.org/job/ci_linux/24070/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18141)](http://ci.ros2.org/job/ci_linux-aarch64/18141/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3468)](http://ci.ros2.org/job/ci_linux-rhel/3468/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24690)](http://ci.ros2.org/job/ci_windows/24690/)