### PR TITLE
Completely unload RMW test fixture when stopped

### DIFF
--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation.cpp
@@ -125,7 +125,14 @@ rmw_test_isolation_start()
 rmw_ret_t
 rmw_test_isolation_stop()
 {
-  return symbol_rmw_test_isolation_stop();
+  rmw_ret_t ret = symbol_rmw_test_isolation_stop();
+
+  g_isolation_lib.reset();
+
+  symbol_rmw_test_isolation_start = rmw_test_isolation_init;
+  symbol_rmw_test_isolation_stop = rmw_test_isolation_stop_noop;
+
+  return ret;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
The initial implementation of the RMW test fixture assumed that we would never attempt to restart the fixture in the same process after switching to a different RMW implementation. During rollout, I found situations where we want to do exactly that.

This small change will cause the fixture discovery to re-run for subsequent fixture starts after gracefully stopping the previous fixture.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24063)](http://ci.ros2.org/job/ci_linux/24063/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18146)](http://ci.ros2.org/job/ci_linux-aarch64/18146/) [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18158)](https://ci.ros2.org/job/ci_linux-aarch64/18158/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3467)](http://ci.ros2.org/job/ci_linux-rhel/3467/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24689)](http://ci.ros2.org/job/ci_windows/24689/) [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24702)](https://ci.ros2.org/job/ci_windows/24702/)