### PR TITLE
Copy all environment variables explicitly

### DIFF
--- a/rmw_test_fixture_implementation/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/CMakeLists.txt
@@ -97,6 +97,8 @@ set_target_properties(_rmw_test_fixture_implementation PROPERTIES
 )
 
 target_link_libraries(_rmw_test_fixture_implementation PRIVATE
+  rcutils::rcutils
+  rmw::rmw
   rmw_test_fixture_implementation
 )
 

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
@@ -16,31 +16,202 @@
 
 #include <Python.h>
 
+#include <rcutils/allocator.h>
+#include <rcutils/strdup.h>
+#include <rcutils/types.h>
+#include <rmw/convert_rcutils_ret_to_rmw_ret.h>
 #include <rmw_test_fixture/rmw_test_fixture.h>
 
-static PyObject * get_fresh_environ(void)
+static rcutils_ret_t add_py_string_to_list(PyObject *py_str, rcutils_array_list_t *list)
+{
+  Py_ssize_t str_size;
+  const char *raw_str = PyUnicode_AsUTF8AndSize(py_str, &str_size);
+  if (NULL == raw_str) {
+    return RCUTILS_RET_ERROR;
+  }
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_char_array_t char_array = rcutils_get_zero_initialized_char_array();
+  rcutils_ret_t ret = rcutils_char_array_init(&char_array, str_size + 1, &allocator);
+  if (ret) {
+    return ret;
+  }
+
+  ret = rcutils_char_array_memcpy(&char_array, raw_str, str_size);
+  if (ret) {
+    if (rcutils_char_array_fini(&char_array)) {
+      RCUTILS_SET_ERROR_MSG("failed to deallocate char_array_t");
+    }
+    return ret;
+  }
+
+  ret = rcutils_array_list_add(list, &char_array);
+  if (ret) {
+    if (rcutils_char_array_fini(&char_array)) {
+      RCUTILS_SET_ERROR_MSG("failed to deallocate char_array_t");
+    }
+    return ret;
+  }
+
+  return RCUTILS_RET_OK;
+}
+
+static rcutils_ret_t py_mapping_to_pair_list(PyObject *mapping, rcutils_array_list_t *pairs)
+{
+  PyObject *items = PyMapping_Items(mapping);
+  if (NULL == items) {
+    return RCUTILS_RET_ERROR;
+  }
+
+  Py_ssize_t size = PyMapping_Size(items);
+  if (-1 == size) {
+    Py_DECREF(items);
+    return RCUTILS_RET_ERROR;
+  }
+
+  rcutils_ret_t ret;
+
+  for (Py_ssize_t i = 0; i < size; i++) {
+    PyObject *pair = PySequence_Fast_GET_ITEM(items, i);
+    if (NULL == pair) {
+      Py_DECREF(items);
+      return RCUTILS_RET_ERROR;
+    }
+
+    PyObject *key = PySequence_Fast_GET_ITEM(pair, 0);
+    if (NULL == key) {
+      Py_DECREF(items);
+      return RCUTILS_RET_ERROR;
+    }
+
+    ret = add_py_string_to_list(key, pairs);
+    if (ret) {
+      Py_DECREF(items);
+      return ret;
+    }
+
+    PyObject *val = PySequence_Fast_GET_ITEM(pair, 1);
+    if (NULL == val) {
+      Py_DECREF(items);
+      return RCUTILS_RET_ERROR;
+    }
+
+    ret = add_py_string_to_list(val, pairs);
+    if (ret) {
+      Py_DECREF(items);
+      return ret;
+    }
+  }
+
+  Py_DECREF(items);
+
+  return RCUTILS_RET_OK;
+}
+
+static PyObject * get_py_string_from_list(rcutils_array_list_t *list, size_t index)
+{
+  rcutils_char_array_t char_array;
+  if (rcutils_array_list_get(list, index, &char_array)) {
+    return NULL;
+  }
+
+  return PyUnicode_FromStringAndSize(char_array.buffer, char_array.buffer_length);
+}
+
+static rcutils_ret_t pair_list_to_py_mapping(rcutils_array_list_t *pairs, PyObject *mapping)
+{
+  size_t size;
+  rcutils_ret_t ret = rcutils_array_list_get_size(pairs, &size);
+  if (ret) {
+    return ret;
+  } else if (size % 2) {
+    return RCUTILS_RET_ERROR;
+  }
+
+  PyObject *res = PyObject_CallMethod(mapping, "clear", NULL);
+  if (NULL == res) {
+    return RCUTILS_RET_ERROR;
+  }
+  Py_DECREF(res);
+
+  for (size_t i = 0; i < size; i += 2) {
+    PyObject *key = get_py_string_from_list(pairs, i);
+    if (NULL == key) {
+      return RCUTILS_RET_ERROR;
+    }
+
+    PyObject *val = get_py_string_from_list(pairs, i + 1);
+    if (NULL == val) {
+      Py_DECREF(key);
+      return RCUTILS_RET_ERROR;
+    }
+
+    if (PyObject_SetItem(mapping, key, val)) {
+      Py_DECREF(val);
+      Py_DECREF(key);
+      return RCUTILS_RET_ERROR;
+    }
+
+    Py_DECREF(val);
+    Py_DECREF(key);
+  }
+
+  return RCUTILS_RET_OK;
+}
+
+static rcutils_ret_t get_fresh_environ(rcutils_array_list_t *pairs)
 {
   PyThreadState *sub_state = Py_NewInterpreter();
   if (NULL == sub_state) {
-    return NULL;
+    return RCUTILS_RET_ERROR;
   }
 
   PyObject *os = PyImport_ImportModule("os");
   if (NULL == os) {
     Py_EndInterpreter(sub_state);
-    return NULL;
+    return RCUTILS_RET_ERROR;
   }
 
   PyObject *os_environ = PyObject_GetAttrString(os, "environ");
   Py_DECREF(os);
   if (NULL == os_environ) {
-    return NULL;
+    Py_EndInterpreter(sub_state);
+    return RCUTILS_RET_ERROR;
   }
 
-  PyObject *fresh_environ = PyMapping_Items(os_environ);
+  rcutils_ret_t ret = py_mapping_to_pair_list(os_environ, pairs);
   Py_DECREF(os_environ);
   Py_EndInterpreter(sub_state);
-  return fresh_environ;
+  return ret;
+}
+
+static rcutils_ret_t fini_array_and_contents(rcutils_array_list_t *array_list)
+{
+  size_t size;
+  rcutils_ret_t ret = rcutils_array_list_get_size(array_list, &size);
+  if (ret) {
+    return ret;
+  }
+
+  for (; size > 0; size--) {
+    rcutils_char_array_t char_array;
+    ret = rcutils_array_list_get(array_list, size - 1, &char_array);
+    if (ret < 0) {
+      return ret;
+    }
+
+    ret = rcutils_array_list_remove(array_list, size - 1);
+    if (ret < 0) {
+      return ret;
+    }
+
+    ret = rcutils_char_array_fini(&char_array);
+    if (ret < 0) {
+      return ret;
+    }
+  }
+
+  return rcutils_array_list_fini(array_list);
 }
 
 /// Reload Python's os.environ from the process values.
@@ -62,41 +233,49 @@ static PyObject * get_fresh_environ(void)
  * \return true if the variables were reloaded successfully, or
  * \return false if an unspecified error occurs.
  */
-static bool reload_environ(void)
+static rmw_ret_t reload_environ(void)
 {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_array_list_t pairs = rcutils_get_zero_initialized_array_list();
+  rcutils_ret_t ret = rcutils_array_list_init(&pairs, 16, sizeof(rcutils_char_array_t), &allocator);
+  if (ret) {
+    return rmw_convert_rcutils_ret_to_rmw_ret(ret);
+  }
+
   PyThreadState *orig_state = PyThreadState_Swap(NULL);
 
-  PyObject * fresh_environ = get_fresh_environ();
+  ret = get_fresh_environ(&pairs);
   PyThreadState_Swap(orig_state);
-  if (NULL == fresh_environ) {
-    return false;
+  if (ret) {
+    fini_array_and_contents(&pairs);
+    return rmw_convert_rcutils_ret_to_rmw_ret(ret);
   }
 
   PyObject *os = PyImport_ImportModule("os");
   if (NULL == os) {
-    Py_DECREF(fresh_environ);
-    return false;
+    fini_array_and_contents(&pairs);
+    return RMW_RET_ERROR;
   }
 
   PyObject *os_environ = PyObject_GetAttrString(os, "environ");
   Py_DECREF(os);
   if (NULL == os_environ) {
-    Py_DECREF(fresh_environ);
-    return false;
+    fini_array_and_contents(&pairs);
+    return RMW_RET_ERROR;
   }
 
   PyObject *res = PyObject_CallMethod(os_environ, "clear", NULL);
   if (NULL == res) {
     Py_DECREF(os_environ);
-    Py_DECREF(fresh_environ);
-    return false;
+    fini_array_and_contents(&pairs);
+    return RMW_RET_ERROR;
   }
 
-  res = PyObject_CallMethod(os_environ, "update", "O", fresh_environ);
+  ret = pair_list_to_py_mapping(&pairs, os_environ);
   Py_DECREF(os_environ);
-  Py_DECREF(fresh_environ);
+  fini_array_and_contents(&pairs);
 
-  return true;
+  return rmw_convert_rcutils_ret_to_rmw_ret(ret);
 }
 
 static PyObject *
@@ -108,8 +287,9 @@ isolation_start(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
     return NULL;
   }
 
-  if (!reload_environ()) {
-    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment");
+  ret = reload_environ();
+  if (ret) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment (%u)", ret);
     return NULL;
   }
 
@@ -125,8 +305,9 @@ isolation_stop(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
     return NULL;
   }
 
-  if (!reload_environ()) {
-    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment");
+  ret = reload_environ();
+  if (ret) {
+    PyErr_Format(PyExc_RuntimeError, "Failed to reload environment (%d)", ret);
     return NULL;
   }
 


### PR DESCRIPTION
## Description

Copying Python objects from a sub-interpreter to the "main" interpreter seems to work fine on Linux, but occasionally causes access violations on Windows. This change copies the raw unicode strings from the environment variables in the sub-interpreter to rcutils-managed data structures and completely frees the sub-interpreter before replacing the Python environment variables with the rcutils-managed ones.

### Is this user-facing behavior change?

No user-facing behavior should change - this is just a bugfix.

### Did you use Generative AI?

No

---

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24026)](http://ci.ros2.org/job/ci_linux/24026/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18110)](http://ci.ros2.org/job/ci_linux-aarch64/18110/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3427)](http://ci.ros2.org/job/ci_linux-rhel/3427/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24666)](http://ci.ros2.org/job/ci_windows/24666/)

---

Python code in C is pretty verbose and it makes this change look a lot bigger than it actually is.

For the sake of review, the high-level flow looks like:
1. Allocate a `rcutils_array_list_t` which holds instances of `rcutils_char_array_t`.
2. Spin up a sub-interpreter and copy the environment variables to the rcutils array in pairs (key, value, key, value, etc)
3. After stopping the sub interpreter and freeing resources, clear `os.enviorn` and copy the unicode strings out of the rcutils array into `os.environ`.
4. Free the rcutils array and members.

I chose not to use `rcutils_string_array_t` or `rcutils_string_map_t` because they assume the string is null-terminated ASCII, and we're working with Unicode here.

---

Additional Context:

All of this python environment variable refresh nonsense can be deprecated when we move to Python 3.14, which adds the `os.reload_environ()` function: https://docs.python.org/3.14/library/os.html#os.reload_environ