### PR TITLE
Ignore SIGINT *after* child process has been spawned

### DIFF
--- a/rmw_test_fixture_implementation/src/run_rmw_isolated.c
+++ b/rmw_test_fixture_implementation/src/run_rmw_isolated.c
@@ -68,14 +68,6 @@ main(int argc, char *argv[])
     return rmw_ret;
   }
 
-  // Let the signal propagate to the child process - this process should only
-  // exit once the child process does.
-#if defined _WIN32 || defined __CYGWIN__
-  SetConsoleCtrlHandler((PHANDLER_ROUTINE)ctrl_c_handler, TRUE);
-#else
-  signal(SIGINT, SIG_IGN);
-#endif
-
   process = rcutils_start_process(&args, &allocator);
   if (NULL == process) {
     fprintf(stderr, "Failed to run %s\n", argv[1]);
@@ -87,6 +79,14 @@ main(int argc, char *argv[])
     fprintf(stderr, "Failed to free argument array (%d)\n", rcutils_ret);
     return rcutils_ret;
   }
+
+  // Let the signal propagate to the child process - this process should only
+  // exit once the child process does.
+#if defined _WIN32 || defined __CYGWIN__
+  SetConsoleCtrlHandler((PHANDLER_ROUTINE)ctrl_c_handler, TRUE);
+#else
+  signal(SIGINT, SIG_IGN);
+#endif
 
   rcutils_ret = rcutils_process_wait(process, &exit_code);
   if (RCUTILS_RET_OK != rcutils_ret) {


### PR DESCRIPTION
## Description

If the child process doesn't configure a SIGINT handler, it's behavior should remain the same as before - the process should terminate. If we set SIG_IGN for SIGINT before spawning the subprocess, the child process seems to inherit the behavior, which we clearly don't want.

### Is this user-facing behavior change?

Yes, running `run_rmw_isolated` with a subprocess which doesn't explicitly configure a SIGINT handler should now behave as expected.

### Did you use Generative AI?

No

---

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=24065)](http://ci.ros2.org/job/ci_linux/24065/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=18144)](http://ci.ros2.org/job/ci_linux-aarch64/18144/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3469)](http://ci.ros2.org/job/ci_linux-rhel/3469/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24691)](http://ci.ros2.org/job/ci_windows/24691/)