### PR TITLE
Add `find_package` call for `rmw`

### DIFF
--- a/rmw_test_fixture/CMakeLists.txt
+++ b/rmw_test_fixture/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rmw_test_fixture LANGUAGES NONE)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros_core REQUIRED)
+find_package(rmw REQUIRED)
 
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE


### PR DESCRIPTION
## Description
While working on compiling a fresh ROS installation from sources, I was running into a build issue specifically on `rmw_test_fixture`. CMake was complaining about `rmw::rmw` being linked, since there was no earlier call to `find_package(rmw REQUIRED)`.

This PR fixes the issue by explicitly adding that line.

I am not sure how this isn't breaking things in mainline builds, perhaps it's due to using a different version of CMake? In my build environment, I am running 3.30.

### Is this user-facing behavior change?
no

### Did you use Generative AI?
no

### Additional Information

