### PR TITLE
Add missing dependency from rmw_test_fixture to rmw

### DIFF
--- a/rmw_test_fixture/package.xml
+++ b/rmw_test_fixture/package.xml
@@ -14,6 +14,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
+  <build_depend>rmw</build_depend>
+
   <build_export_depend>rmw</build_export_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

It appears that #50 added a build-time dependency on `rmw` but didn't declare it. This is [breaking Kilted builds now](https://build.ros2.org/view/Kbin_uN64/job/Kbin_uN64__rmw_test_fixture__ubuntu_noble_amd64__binary/), and will break Rolling builds when ros/rosdistro#48203 is merged.

### Is this user-facing behavior change?

Yes, it fixes the build

### Did you use Generative AI?

No

### Additional Information

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=25480)](http://ci.ros2.org/job/ci_linux/25480/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=19558)](http://ci.ros2.org/job/ci_linux-aarch64/19558/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=5008)](http://ci.ros2.org/job/ci_linux-rhel/5008/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25772)](http://ci.ros2.org/job/ci_windows/25772/)