### PR TITLE
default to c++17 due to use of newer methods on std::map

### DIFF
--- a/rmw_test_fixture_implementation/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 project(rmw_test_fixture_implementation LANGUAGES C CXX)
 
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
## Description

Fixes #54 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Other packages do similar, e.g. https://github.com/ros2/rcpputils/blob/6f2f0a1cc80ca599a5851b84085e587d01d6944d/CMakeLists.txt#L14-L17
