### PR TITLE
Restore ROS_DOMAIN_ID after isolation is finished

### DIFF
--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -45,6 +45,7 @@
 #include <rcutils/env.h>
 #include <rcutils/format_string.h>
 #include <rcutils/process.h>
+#include <rcutils/strdup.h>
 #include <rmw/types.h>
 
 #if defined _WIN32 || defined __CYGWIN__
@@ -60,6 +61,8 @@ static port_lock_t g_lock = INVALID_PORT_LOCK;
 static unsigned int g_random_seed;
 
 static bool g_random_seed_initialized = false;
+
+static char *g_restore_domain_id = NULL;
 
 static
 void
@@ -182,7 +185,26 @@ rmw_test_isolation_start_default(void)
   // Avoid ROS_DOMAIN_ID=0 entirely
   slot += 1;
 
+  const char *old_env_val;
+  if (NULL == rcutils_get_env("ROS_DOMAIN_ID", &old_env_val)) {
+    fprintf(stderr, "Failed to get ROS_DOMAIN_ID\n");
+    port_lock_fini(g_lock);
+    g_lock = INVALID_PORT_LOCK;
+    return RMW_RET_ERROR;
+  }
+
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  if (NULL != g_restore_domain_id) {
+    allocator.deallocate(g_restore_domain_id, allocator.state);
+  }
+  g_restore_domain_id = rcutils_strdup(old_env_val, allocator);
+  if (NULL == g_restore_domain_id) {
+    fprintf(stderr, "Failed save old ROS_DOMAIN_ID\n");
+    port_lock_fini(g_lock);
+    g_lock = INVALID_PORT_LOCK;
+    return RMW_RET_ERROR;
+  }
+
   char *env_val = rcutils_format_string(allocator, "%d", slot);
   if (NULL == env_val) {
     fprintf(stderr, "Failed to format ROS_DOMAIN_ID value\n");
@@ -207,8 +229,14 @@ rmw_test_isolation_start_default(void)
 rmw_ret_t
 rmw_test_isolation_stop_default(void)
 {
-  if (!rcutils_set_env("ROS_DOMAIN_ID", NULL)) {
-    fprintf(stderr, "Failed to clear ROS_DOMAIN_ID\n");
+  if (!rcutils_set_env("ROS_DOMAIN_ID", g_restore_domain_id)) {
+    fprintf(stderr, "Failed to restore ROS_DOMAIN_ID\n");
+  }
+
+  if (NULL != g_restore_domain_id) {
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    allocator.deallocate(g_restore_domain_id, allocator.state);
+    g_restore_domain_id = NULL;
   }
 
   port_lock_fini(g_lock);

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -196,6 +196,7 @@ rmw_test_isolation_start_default(void)
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   if (NULL != g_restore_domain_id) {
     allocator.deallocate(g_restore_domain_id, allocator.state);
+    g_restore_domain_id = NULL;
   }
   g_restore_domain_id = rcutils_strdup(old_env_val, allocator);
   if (NULL == g_restore_domain_id) {

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_default/rmw_test_fixture_default.c
@@ -186,7 +186,7 @@ rmw_test_isolation_start_default(void)
   slot += 1;
 
   const char *old_env_val;
-  if (NULL == rcutils_get_env("ROS_DOMAIN_ID", &old_env_val)) {
+  if (NULL != rcutils_get_env("ROS_DOMAIN_ID", &old_env_val)) {
     fprintf(stderr, "Failed to get ROS_DOMAIN_ID\n");
     port_lock_fini(g_lock);
     g_lock = INVALID_PORT_LOCK;
@@ -198,12 +198,17 @@ rmw_test_isolation_start_default(void)
     allocator.deallocate(g_restore_domain_id, allocator.state);
     g_restore_domain_id = NULL;
   }
-  g_restore_domain_id = rcutils_strdup(old_env_val, allocator);
-  if (NULL == g_restore_domain_id) {
-    fprintf(stderr, "Failed save old ROS_DOMAIN_ID\n");
-    port_lock_fini(g_lock);
-    g_lock = INVALID_PORT_LOCK;
-    return RMW_RET_ERROR;
+  if (strlen(old_env_val) > 0) {
+    // rcutils_get_env yields an empty string if the variable is not set.
+    // An empty ROS_DOMAIN_ID is not valid, so we should interpret an empty
+    // value as "unset" and therefore pass NULL to rcutils_set_env on stop.
+    g_restore_domain_id = rcutils_strdup(old_env_val, allocator);
+    if (NULL == g_restore_domain_id) {
+      fprintf(stderr, "Failed save old ROS_DOMAIN_ID\n");
+      port_lock_fini(g_lock);
+      g_lock = INVALID_PORT_LOCK;
+      return RMW_RET_ERROR;
+    }
   }
 
   char *env_val = rcutils_format_string(allocator, "%d", slot);


### PR DESCRIPTION
## Description

Rather than clearing the ROS_DOMAIN_ID environment variable after we stop RMW communication isolation, set it back to whatever it was before isolation was started.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=25632)](http://ci.ros2.org/job/ci_linux/25632/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=19668)](http://ci.ros2.org/job/ci_linux-aarch64/19668/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=5191)](http://ci.ros2.org/job/ci_linux-rhel/5191/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25861)](http://ci.ros2.org/job/ci_windows/25861/)