### PR TITLE
Drop group dependency on test fixtures

### DIFF
--- a/rmw_test_fixture_implementation/package.xml
+++ b/rmw_test_fixture_implementation/package.xml
@@ -18,9 +18,6 @@
   <build_depend>rmw_implementation</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
 
-  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
-  <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_zenoh_cpp</exec_depend>
-
   <exec_depend>rpyutils</exec_depend>
 
   <depend>rcpputils</depend>
@@ -32,8 +29,6 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-
-  <group_depend>rmw_test_fixture_implementation_packages</group_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

At the moment, all providers of test fixtures have implemented the fixture in the same package which provides the RMW itself, meaning that we don't need to use a dependency to ensure that the plugin is present when the RMW is tested.

Having the dependency here means that all packages which implement a plugin are upstream of this package, which inflates the dependency tree in an undesirable way.

Fixes ros2/ros2#1770

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=26385)](http://ci.ros2.org/job/ci_linux/26385/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=20033)](http://ci.ros2.org/job/ci_linux-aarch64/20033/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=6087)](http://ci.ros2.org/job/ci_linux-rhel/6087/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=26121)](http://ci.ros2.org/job/ci_windows/26121/)