### PR TITLE
Block signals during Python environment reload in rmw_test_fixture_implementation

### DIFF
--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
@@ -240,6 +240,9 @@ static rcutils_ret_t fini_array_and_contents(rcutils_array_list_t *array_list)
 static rmw_ret_t reload_environ(void)
 {
 #ifndef _WIN32
+  // Mask signals during environment reload to prevent fatal Python errors
+  // (init_import_site: Failed to import the site module) caused by signals
+  // interrupting sub-interpreter initialization.
   sigset_t set, oldset;
   sigemptyset(&set);
   sigaddset(&set, SIGINT);

--- a/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
+++ b/rmw_test_fixture_implementation/src/rmw_test_fixture_implementation_py.c
@@ -14,6 +14,10 @@
 
 #include <stdbool.h>
 
+#ifndef _WIN32
+#include <signal.h>
+#endif
+
 #include <Python.h>
 
 #include <rcutils/allocator.h>
@@ -235,10 +239,21 @@ static rcutils_ret_t fini_array_and_contents(rcutils_array_list_t *array_list)
  */
 static rmw_ret_t reload_environ(void)
 {
+#ifndef _WIN32
+  sigset_t set, oldset;
+  sigemptyset(&set);
+  sigaddset(&set, SIGINT);
+  sigaddset(&set, SIGTERM);
+  sigprocmask(SIG_BLOCK, &set, &oldset);
+#endif
+
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcutils_array_list_t pairs = rcutils_get_zero_initialized_array_list();
   rcutils_ret_t ret = rcutils_array_list_init(&pairs, 16, sizeof(rcutils_char_array_t), &allocator);
   if (ret) {
+#ifndef _WIN32
+    sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
     return rmw_convert_rcutils_ret_to_rmw_ret(ret);
   }
 
@@ -248,12 +263,18 @@ static rmw_ret_t reload_environ(void)
   PyThreadState_Swap(orig_state);
   if (ret) {
     fini_array_and_contents(&pairs);
+#ifndef _WIN32
+    sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
     return rmw_convert_rcutils_ret_to_rmw_ret(ret);
   }
 
   PyObject *os = PyImport_ImportModule("os");
   if (NULL == os) {
     fini_array_and_contents(&pairs);
+#ifndef _WIN32
+    sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
     return RMW_RET_ERROR;
   }
 
@@ -261,6 +282,9 @@ static rmw_ret_t reload_environ(void)
   Py_DECREF(os);
   if (NULL == os_environ) {
     fini_array_and_contents(&pairs);
+#ifndef _WIN32
+    sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
     return RMW_RET_ERROR;
   }
 
@@ -268,12 +292,19 @@ static rmw_ret_t reload_environ(void)
   if (NULL == res) {
     Py_DECREF(os_environ);
     fini_array_and_contents(&pairs);
+#ifndef _WIN32
+    sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
     return RMW_RET_ERROR;
   }
 
   ret = pair_list_to_py_mapping(&pairs, os_environ);
   Py_DECREF(os_environ);
   fini_array_and_contents(&pairs);
+
+#ifndef _WIN32
+  sigprocmask(SIG_SETMASK, &oldset, NULL);
+#endif
 
   return rmw_convert_rcutils_ret_to_rmw_ret(ret);
 }
@@ -322,7 +353,7 @@ static PyMethodDef module_methods[] = {
 
 static struct PyModuleDef module = {
   PyModuleDef_HEAD_INIT,
-  "_rmw_test_fixtupre_implementation",
+  "_rmw_test_fixture_implementation",
   NULL,
   -1,
   module_methods,


### PR DESCRIPTION
## Description

This PR addresses a fatal Python error `init_import_site: Failed to import the site module` that can occur during RMW-isolated testing, particularly when tests are shutting down quickly.

The `reload_environ` function in the Python bindings for `rmw_test_fixture_implementation` uses `Py_NewInterpreter` to refresh environment variables. This initialization of a sub-interpreter is sensitive to asynchronous signals. If a `SIGINT` or `SIGTERM` is delivered while the sub-interpreter is initializing its `site` module, Python crashes with a fatal error or a segmentation fault.

Fixes https://github.com/ros2/examples/issues/446

### Is this user-facing behavior change?

### Did you use Generative AI?

Yes. Gemini CLI:2.0-Flash [web_fetch, list_directory, grep_search, glob, read_file, run_shell_command, write_file, replace, google_web_search]

### Additional Information

*   Block `SIGINT` and `SIGTERM` using `sigprocmask` (on non-Windows platforms) during the entire execution of `reload_environ`.
*   Fixed a typo in the module name: `_rmw_test_fixtupre_implementation` -> `_rmw_test_fixture_implementation`.
*   Verified with a [reproduction script](https://gist.github.com/mjcarroll/85c8711263c9d91b4d7b30eeb5c1d9df) that the crash no longer occurs under heavy signal pressure.
*   Ran package tests, which pass successfully.