### PR TITLE
Add `ament_ros_defaults` target (manual Kilted backport of #62)

### DIFF
--- a/ament_cmake_ros_core/CMakeLists.txt
+++ b/ament_cmake_ros_core/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ament_cmake_ros_core NONE)
 
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
+find_package(ament_cmake_export_targets REQUIRED)
 
 ament_export_dependencies(ament_cmake_core)
 
@@ -11,6 +12,20 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/ament_ros_defaults.cmake")
+
+install(
+  TARGETS
+    ament_ros_defaults
+    ament_ros_cxx_standard
+    ament_ros_c_standard
+  EXPORT ament_ros_core_targets
+)
+
+ament_export_targets(
+  ament_ros_core_targets
+)
 
 ament_package(
   CONFIG_EXTRAS "ament_cmake_ros_core-extras.cmake.in"

--- a/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
+++ b/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
@@ -1,0 +1,25 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(ament_ros_cxx_standard INTERFACE)
+target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_20)
+
+add_library(ament_ros_c_standard INTERFACE)
+target_compile_features(ament_ros_c_standard INTERFACE c_std_17)
+
+add_library(ament_ros_defaults INTERFACE)
+target_link_libraries(ament_ros_defaults INTERFACE
+  ament_ros_cxx_standard
+  ament_ros_c_standard
+)

--- a/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
+++ b/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 add_library(ament_ros_cxx_standard INTERFACE)
-target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_20)
+target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_17)
 
 add_library(ament_ros_c_standard INTERFACE)
-target_compile_features(ament_ros_c_standard INTERFACE c_std_17)
+target_compile_features(ament_ros_c_standard INTERFACE c_std_11)
 
 add_library(ament_ros_defaults INTERFACE)
 target_link_libraries(ament_ros_defaults INTERFACE

--- a/ament_cmake_ros_core/package.xml
+++ b/ament_cmake_ros_core/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_targets</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>ament_cmake_libraries</buildtool_export_depend>

--- a/rmw_test_fixture_implementation/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(rmw_test_fixture_implementation LANGUAGES C CXX)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
@@ -50,6 +45,7 @@ target_compile_definitions(rmw_test_fixture_implementation PRIVATE
   "RMW_TEST_FIXTURE_BUILDING_DLL"
 )
 target_link_libraries(rmw_test_fixture_implementation PRIVATE
+  ament_cmake_ros_core::ament_ros_defaults
   rcpputils::rcpputils
   rcutils::rcutils
   rmw::rmw
@@ -72,6 +68,7 @@ add_executable(run_rmw_isolated
   src/run_rmw_isolated.c
 )
 target_link_libraries(run_rmw_isolated
+  ament_cmake_ros_core::ament_ros_defaults
   rcutils::rcutils
   rmw_test_fixture_implementation
 )
@@ -94,6 +91,7 @@ if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 target_link_libraries(_rmw_test_fixture_implementation PRIVATE
+  ament_cmake_ros_core::ament_ros_defaults
   rcutils::rcutils
   rmw::rmw
   rmw_test_fixture_implementation

--- a/rmw_test_fixture_implementation/test/CMakeLists.txt
+++ b/rmw_test_fixture_implementation/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_pytest REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 
 add_library(rmw_mockmock_test_fixture SHARED
   rmw_mockmock_test_fixture.c
@@ -11,6 +12,7 @@ target_compile_definitions(rmw_mockmock_test_fixture PRIVATE
 
 target_link_libraries(rmw_mockmock_test_fixture
   PRIVATE
+    ament_cmake_ros_core::ament_ros_defaults
     rcutils::rcutils
     rmw_test_fixture::rmw_test_fixture
 )
@@ -24,6 +26,7 @@ ament_add_gtest(test_fixture_start_stop
 )
 
 target_link_libraries(test_fixture_start_stop
+  ament_cmake_ros_core::ament_ros_defaults
   rcpputils::rcpputils
   rmw_test_fixture::rmw_test_fixture
   rmw_test_fixture_implementation


### PR DESCRIPTION
## Description

Manual backport of #62 to Kilted.

### Is this user-facing behavior change?

Practically not. But the user can start depending on `ament_ros_defaults` in downstream packages.

### Did you use Generative AI?

No.

### Additional Information

C++ version set to C++17, C version to C11, according to REP-2000.
