### PR TITLE
Split generic parts of ament_cmake_ros into _core package + Add `ament_ros_defaults` target (manual Humble backport of #20 and #62)

### DIFF
--- a/ament_cmake_ros_core/CMakeLists.txt
+++ b/ament_cmake_ros_core/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(ament_cmake_ros_core NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_export_dependencies REQUIRED)
+
+ament_export_dependencies(ament_cmake_core)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "ament_cmake_ros_core-extras.cmake.in"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)

--- a/ament_cmake_ros_core/CMakeLists.txt
+++ b/ament_cmake_ros_core/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ament_cmake_ros_core NONE)
 
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
+find_package(ament_cmake_export_targets REQUIRED)
 
 ament_export_dependencies(ament_cmake_core)
 
@@ -11,6 +12,20 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/ament_ros_defaults.cmake")
+
+install(
+  TARGETS
+    ament_ros_defaults
+    ament_ros_cxx_standard
+    ament_ros_c_standard
+  EXPORT ament_ros_core_targets
+)
+
+ament_export_targets(
+  ament_ros_core_targets
+)
 
 ament_package(
   CONFIG_EXTRAS "ament_cmake_ros_core-extras.cmake.in"

--- a/ament_cmake_ros_core/ament_cmake_ros_core-extras.cmake.in
+++ b/ament_cmake_ros_core/ament_cmake_ros_core-extras.cmake.in
@@ -1,0 +1,15 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generated from ament_cmake_ros_core/ament_cmake_ros_core-extras.cmake.in

--- a/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
+++ b/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
@@ -1,0 +1,25 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(ament_ros_cxx_standard INTERFACE)
+target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_20)
+
+add_library(ament_ros_c_standard INTERFACE)
+target_compile_features(ament_ros_c_standard INTERFACE c_std_17)
+
+add_library(ament_ros_defaults INTERFACE)
+target_link_libraries(ament_ros_defaults INTERFACE
+    ament_ros_cxx_standard
+    ament_ros_c_standard
+)

--- a/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
+++ b/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 add_library(ament_ros_cxx_standard INTERFACE)
-target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_20)
+target_compile_features(ament_ros_cxx_standard INTERFACE cxx_std_17)
 
 add_library(ament_ros_c_standard INTERFACE)
-target_compile_features(ament_ros_c_standard INTERFACE c_std_17)
+target_compile_features(ament_ros_c_standard INTERFACE c_std_11)
 
 add_library(ament_ros_defaults INTERFACE)
 target_link_libraries(ament_ros_defaults INTERFACE

--- a/ament_cmake_ros_core/package.xml
+++ b/ament_cmake_ros_core/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
   <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_targets</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 

--- a/ament_cmake_ros_core/package.xml
+++ b/ament_cmake_ros_core/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>ament_cmake_ros_core</name>
+  <version>0.13.1</version>
+  <description>Core ROS specific CMake bits in the ament buildsystem.</description>
+
+  <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
+  <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

Manual backport of #20 and #62 to Humble.

### Is this user-facing behavior change?

Not. But the user can start depending on `ament_ros_defaults` in downstream packages.

### Did you use Generative AI?

No.

### Additional Information

C++ version set to C++17, C version to C11, according to REP-2000.

I decided to not move `build_shared_libs.cmake` from ament_cmake_ros to ament_cmake_ros_core as done in #20 as that could be a breaking change. So this PR does not change the behavior of existing code/packages at all, just adds the new package.
